### PR TITLE
normalize quotes before passing to shlex

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -15,6 +15,30 @@ import (
 
 var _KwargPattern = regexp.MustCompile(`^([a-zA-Z_\d]+)=(.*)$`)
 
+func normalizeSmartQuotes(s string) string {
+	replacements := map[rune]string{
+		'\u2018': "'",  // Left single quote
+		'\u2019': "'",  // Right single quote
+		'\u201C': "\"", // Left double quote
+		'\u201D': "\"", // Right double quote
+		'\u201B': "'",  // Single high-reversed-9 quote
+		'\u201A': "'",  // Single low-9 quote
+		'\u201F': "\"", // Double high-reversed-9 quote
+		'\u201E': "\"", // Double low-9 quote
+	}
+
+	var result strings.Builder
+	for _, r := range s {
+		if replacement, exists := replacements[r]; exists {
+			result.WriteString(replacement)
+		} else {
+			result.WriteRune(r)
+		}
+	}
+
+	return result.String()
+}
+
 // Command represents an individual Discord command.
 type Command struct {
 	description string
@@ -61,7 +85,8 @@ func (parser *Parser) RunCommand(message *discordgo.MessageCreate) error {
 		return nil
 	}
 
-	arguments, err := shlex.Split(message.Content)
+	normalizedContent := normalizeSmartQuotes(message.Content)
+	arguments, err := shlex.Split(normalizedContent)
 	arguments[0] = strings.TrimPrefix(arguments[0], parser.prefix)
 	if err != nil {
 		return fmt.Errorf("error parsing arguments: %w", err)

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,6 +2,7 @@ package parsley
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -398,6 +399,39 @@ func TestRunCommandWithKwargAndDefault(t *testing.T) {
 	err := parser.RunCommand(&discordgo.MessageCreate{Message: &discordgo.Message{Content: ". Arg2=overridden"}})
 	if err != nil {
 		t.Errorf("running command returned unexpected error")
+	}
+}
+
+func TestRunCommandWithUnicodeQuotes(t *testing.T) {
+	unicodeQuotes := []rune{
+		0x2018, 0x2019, 0x201C, 0x201D,
+		0x201B, 0x201A, 0x201F, 0x201E,
+	}
+
+	for _, quote := range unicodeQuotes {
+		t.Run(
+			fmt.Sprintf("QuoteU+%X", quote), func(t *testing.T) {
+				parser := New(".")
+				parser.NewCommand("", "", func(message *discordgo.MessageCreate, args struct {
+					Arg1 string
+					Arg2 string `default:"default"`
+				}) {
+					if args.Arg1 != "first arg" {
+						t.Errorf("handler was not passed correct value for Arg1 (expected 'first arg', got '%s')", args.Arg1)
+					}
+					if args.Arg2 != "default" {
+						t.Errorf("handler was not passed correct value for Arg2 (expected 'default', got '%s')", args.Arg2)
+					}
+				})
+
+				err := parser.RunCommand(&discordgo.MessageCreate{Message: &discordgo.Message{
+					Content: fmt.Sprintf(". %cfirst arg%c", quote, quote),
+				}})
+				if err != nil {
+					t.Errorf("running command returned unexpected error: %v", err)
+				}
+			},
+		)
 	}
 }
 


### PR DESCRIPTION
| Character | Unicode | Name | Normalizes to |
|----------|---------|------|---------------|
| ‘ | U+2018 | Left single quotation mark | `'` |
| ’ | U+2019 | Right single quotation mark | `'` |
| ‛ | U+201B | Single high-reversed-9 quotation mark | `'` |
| ‚ | U+201A | Single low-9 quotation mark | `'` |
| “ | U+201C | Left double quotation mark | `"` |
| ” | U+201D | Right double quotation mark | `"` |
| ‟ | U+201F | Double high-reversed-9 quotation mark | `"` |
| „ | U+201E | Double low-9 quotation mark | `"` |