### PR TITLE
multiple prefixes

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -83,9 +83,6 @@ func (parser *Parser) NewCommand(name, description string, handler interface{}) 
 func (parser *Parser) RunCommand(message *discordgo.MessageCreate) error {
 	var matchedPrefix *string
 	for _, prefix := range parser.prefixes {
-		if prefix == "" {
-			continue
-		}
 		if strings.HasPrefix(message.Content, prefix) {
 			matchedPrefix = &prefix
 			break

--- a/parser.go
+++ b/parser.go
@@ -81,20 +81,23 @@ func (parser *Parser) NewCommand(name, description string, handler interface{}) 
 
 // RunCommand parses the content of a specific message and runs the associated command, if found.
 func (parser *Parser) RunCommand(message *discordgo.MessageCreate) error {
-	matchedPrefix := ""
+	var matchedPrefix *string
 	for _, prefix := range parser.prefixes {
+		if prefix == "" {
+			continue
+		}
 		if strings.HasPrefix(message.Content, prefix) {
-			matchedPrefix = prefix
+			matchedPrefix = &prefix
 			break
 		}
 	}
-	if matchedPrefix == "" {
+	if matchedPrefix == nil {
 		return nil
 	}
 
 	normalizedContent := normalizeSmartQuotes(message.Content)
 	arguments, err := shlex.Split(normalizedContent)
-	arguments[0] = strings.TrimPrefix(arguments[0], matchedPrefix)
+	arguments[0] = strings.TrimPrefix(arguments[0], *matchedPrefix)
 	if err != nil {
 		return fmt.Errorf("error parsing arguments: %w", err)
 	}

--- a/parser.go
+++ b/parser.go
@@ -63,7 +63,7 @@ type CommandDetails struct {
 
 // Parser represents a parser for Discord commands.
 type Parser struct {
-	prefix   string
+	prefixes []string
 	commands map[string]Command
 }
 
@@ -81,13 +81,20 @@ func (parser *Parser) NewCommand(name, description string, handler interface{}) 
 
 // RunCommand parses the content of a specific message and runs the associated command, if found.
 func (parser *Parser) RunCommand(message *discordgo.MessageCreate) error {
-	if !strings.HasPrefix(message.Content, parser.prefix) {
+	matchedPrefix := ""
+	for _, prefix := range parser.prefixes {
+		if strings.HasPrefix(message.Content, prefix) {
+			matchedPrefix = prefix
+			break
+		}
+	}
+	if matchedPrefix == "" {
 		return nil
 	}
 
 	normalizedContent := normalizeSmartQuotes(message.Content)
 	arguments, err := shlex.Split(normalizedContent)
-	arguments[0] = strings.TrimPrefix(arguments[0], parser.prefix)
+	arguments[0] = strings.TrimPrefix(arguments[0], matchedPrefix)
 	if err != nil {
 		return fmt.Errorf("error parsing arguments: %w", err)
 	}
@@ -293,9 +300,10 @@ func (parser *Parser) GetCommands() []CommandDetails {
 }
 
 // New creates a new Parsley parser.
-func New(prefix string) *Parser {
+func New(prefixes ...string) *Parser {
 	return &Parser{
-		prefix, make(map[string]Command, 0),
+		prefixes: prefixes,
+		commands: make(map[string]Command, 0),
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -302,11 +302,6 @@ func (parser *Parser) GetCommands() []CommandDetails {
 	return commandDetails
 }
 
-// Prefixes returns the prefixes the parser is configured with.
-func (parser *Parser) Prefixes() []string {
-	return parser.prefixes
-}
-
 // New creates a new Parsley parser.
 func New(prefixes ...string) *Parser {
 	return &Parser{

--- a/parser.go
+++ b/parser.go
@@ -299,6 +299,11 @@ func (parser *Parser) GetCommands() []CommandDetails {
 	return commandDetails
 }
 
+// Prefixes returns the prefixes the parser is configured with.
+func (parser *Parser) Prefixes() []string {
+	return parser.prefixes
+}
+
 // New creates a new Parsley parser.
 func New(prefixes ...string) *Parser {
 	return &Parser{

--- a/parser_test.go
+++ b/parser_test.go
@@ -578,3 +578,74 @@ func TestGetCommandsWithNoCommands(t *testing.T) {
 		t.Error(diff)
 	}
 }
+
+func TestNewParserWithMultiplePrefixes(t *testing.T) {
+	parser := New("test!", ",")
+	if len(parser.prefixes) != 2 {
+		t.Errorf("parser was returned with incorrect number of prefixes: %d", len(parser.prefixes))
+	}
+	if parser.prefixes[0] != "test!" {
+		t.Errorf("parser first prefix was incorrect: %s", parser.prefixes[0])
+	}
+	if parser.prefixes[1] != "," {
+		t.Errorf("parser second prefix was incorrect: %s", parser.prefixes[1])
+	}
+}
+
+func TestRunCommandWithFirstPrefix(t *testing.T) {
+	parser := New("!", ",")
+	called := false
+	parser.NewCommand("test", "", func(message *discordgo.MessageCreate, args struct{}) {
+		called = true
+	})
+
+	err := parser.RunCommand(&discordgo.MessageCreate{Message: &discordgo.Message{Content: "!test"}})
+	if err != nil {
+		t.Errorf("running command returned unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("command handler was not called")
+	}
+}
+
+func TestRunCommandWithSecondPrefix(t *testing.T) {
+	parser := New("!", ",")
+	called := false
+	parser.NewCommand("test", "", func(message *discordgo.MessageCreate, args struct{}) {
+		called = true
+	})
+
+	err := parser.RunCommand(&discordgo.MessageCreate{Message: &discordgo.Message{Content: ",test"}})
+	if err != nil {
+		t.Errorf("running command returned unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("command handler was not called")
+	}
+}
+
+func TestRunCommandWithNonMatchingPrefixMultiple(t *testing.T) {
+	parser := New("!", ",")
+
+	err := parser.RunCommand(&discordgo.MessageCreate{Message: &discordgo.Message{Content: ".test"}})
+	if err != nil {
+		t.Errorf("running command returned unexpected error: %v", err)
+	}
+}
+
+func TestRunCommandWithOverlappingPrefixes(t *testing.T) {
+	parser := New("test!", "test")
+	called := false
+	parser.NewCommand("hello", "", func(message *discordgo.MessageCreate, args struct{}) {
+		called = true
+	})
+
+	// "test!hello" should match "test!" first, yielding command "hello"
+	err := parser.RunCommand(&discordgo.MessageCreate{Message: &discordgo.Message{Content: "test!hello"}})
+	if err != nil {
+		t.Errorf("running command returned unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("command handler was not called")
+	}
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -635,13 +635,17 @@ func TestRunCommandWithNonMatchingPrefixMultiple(t *testing.T) {
 
 func TestRunCommandWithEmptyStringPrefix(t *testing.T) {
 	parser := New("")
+	called := false
 	parser.NewCommand("test", "", func(message *discordgo.MessageCreate, args struct{}) {
-		t.Error("command handler should not be called with empty string prefix")
+		called = true
 	})
 
 	err := parser.RunCommand(&discordgo.MessageCreate{Message: &discordgo.Message{Content: "test"}})
 	if err != nil {
 		t.Errorf("running command returned unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("command handler should be called with empty string prefix")
 	}
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -633,6 +633,18 @@ func TestRunCommandWithNonMatchingPrefixMultiple(t *testing.T) {
 	}
 }
 
+func TestRunCommandWithEmptyStringPrefix(t *testing.T) {
+	parser := New("")
+	parser.NewCommand("test", "", func(message *discordgo.MessageCreate, args struct{}) {
+		t.Error("command handler should not be called with empty string prefix")
+	})
+
+	err := parser.RunCommand(&discordgo.MessageCreate{Message: &discordgo.Message{Content: "test"}})
+	if err != nil {
+		t.Errorf("running command returned unexpected error: %v", err)
+	}
+}
+
 func TestRunCommandWithOverlappingPrefixes(t *testing.T) {
 	parser := New("test!", "test")
 	called := false

--- a/parser_test.go
+++ b/parser_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestNewParser(t *testing.T) {
 	parser := New("test")
-	if parser.prefix != "test" {
-		t.Errorf("parser was returned with incorrect prefix %s", parser.prefix)
+	if len(parser.prefixes) != 1 || parser.prefixes[0] != "test" {
+		t.Errorf("parser was returned with incorrect prefixes %v", parser.prefixes)
 	}
 	if len(parser.commands) != 0 {
 		t.Error("parser was returned with non-empty initial command list")


### PR DESCRIPTION
this is a breaking change for anything that would read Parser directly, but `.New` is now variadic, so should be backwards compat there

this is being done to support https://github.com/fogo-sh/borik/issues/82

- **feat: support multiple prefixes via variadic New()**
- **test: add tests for multiple prefix support**
- **feat: add Prefixes() accessor method**
